### PR TITLE
Directive for Oneof Objects and Oneof Input Objects

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -20,6 +20,7 @@ words:
   - graphiql
   - sublinks
   - instanceof
+  - oneof
 
   # Different names used inside tests
   - Skywalker

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export {
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
+  GraphQLOneOfDirective,
   // "Enum" of Type Kinds
   TypeKind,
   // Constant Deprecation Reason

--- a/src/type/__tests__/introspection-test.ts
+++ b/src/type/__tests__/introspection-test.ts
@@ -372,6 +372,17 @@ describe('Introspection', () => {
                   isDeprecated: false,
                   deprecationReason: null,
                 },
+                {
+                  name: 'oneOf',
+                  args: [],
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'Boolean',
+                    ofType: null,
+                  },
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
               ],
               inputFields: null,
               interfaces: [],
@@ -1520,6 +1531,84 @@ describe('Introspection', () => {
           trueFields: [{ name: 'nonDeprecated' }, { name: 'deprecated' }],
           falseFields: [{ name: 'nonDeprecated' }],
           omittedFields: [{ name: 'nonDeprecated' }],
+        },
+      },
+    });
+  });
+
+  it('identifies oneOf for objects', () => {
+    const schema = buildSchema(`
+      type SomeObject @oneOf {
+        a: String
+      }
+
+      type AnotherObject {
+        a: String
+        b: String
+      }
+
+      type Query {
+        someField: String
+      }
+    `);
+
+    const source = `
+      {
+        a: __type(name: "SomeObject") {
+          oneOf
+        }
+        b: __type(name: "AnotherObject") {
+          oneOf
+        }
+      }
+    `;
+
+    expect(graphqlSync({ schema, source })).to.deep.equal({
+      data: {
+        a: {
+          oneOf: true,
+        },
+        b: {
+          oneOf: false,
+        },
+      },
+    });
+  });
+
+  it('identifies oneOf for input objects', () => {
+    const schema = buildSchema(`
+      input SomeInputObject @oneOf {
+        a: String
+      }
+
+      input AnotherInputObject {
+        a: String
+        b: String
+      }
+
+      type Query {
+        someField(someArg: SomeInputObject): String
+      }
+    `);
+
+    const source = `
+      {
+        a: __type(name: "SomeInputObject") {
+          oneOf
+        }
+        b: __type(name: "AnotherInputObject") {
+          oneOf
+        }
+      }
+    `;
+
+    expect(graphqlSync({ schema, source })).to.deep.equal({
+      data: {
+        a: {
+          oneOf: true,
+        },
+        b: {
+          oneOf: false,
         },
       },
     });

--- a/src/type/__tests__/introspection-test.ts
+++ b/src/type/__tests__/introspection-test.ts
@@ -989,6 +989,12 @@ describe('Introspection', () => {
                 },
               ],
             },
+            {
+              name: 'oneOf',
+              isRepeatable: false,
+              locations: ['OBJECT', 'INPUT_OBJECT'],
+              args: [],
+            },
           ],
         },
       },

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -336,7 +336,7 @@ describe('Type System: A Schema must have Object root types', () => {
     ]);
   });
 
-  it('rejects a schema extended with invalid root types', () => {
+  it('rejects a Schema extended with invalid root types', () => {
     let schema = buildSchema(`
       input SomeInputObject {
         test: String
@@ -1658,6 +1658,69 @@ describe('Type System: Input Object fields must have input types', () => {
         message:
           'The type of SomeInputObject.foo must be Input Type but got: SomeObject.',
         locations: [{ line: 7, column: 14 }],
+      },
+    ]);
+  });
+});
+
+describe('Type System: Oneof Object fields must be nullable', () => {
+  it('rejects non-nullable fields', () => {
+    const schema = buildSchema(`
+      type Query {
+        test: SomeObject
+      }
+
+      type SomeObject @oneOf {
+        a: String
+        b: String!
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Field SomeObject.b must be nullable as it is part of a Oneof Type.',
+        locations: [{ line: 8, column: 12 }],
+      },
+    ]);
+  });
+});
+
+describe('Type System: Oneof Input Object fields must be nullable', () => {
+  it('rejects non-nullable fields', () => {
+    const schema = buildSchema(`
+      type Query {
+        test(arg: SomeInputObject): String
+      }
+
+      input SomeInputObject @oneOf {
+        a: String
+        b: String!
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message: 'Oneof input field SomeInputObject.b must be nullable.',
+        locations: [{ line: 8, column: 12 }],
+      },
+    ]);
+  });
+
+  it('rejects fields with default values', () => {
+    const schema = buildSchema(`
+      type Query {
+        test(arg: SomeInputObject): String
+      }
+
+      input SomeInputObject @oneOf {
+        a: String
+        b: String = "foo"
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Oneof input field SomeInputObject.b cannot have a default value.',
+        locations: [{ line: 8, column: 9 }],
       },
     ]);
   });

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -757,6 +757,7 @@ export class GraphQLObjectType<TSource = any, TContext = any> {
   extensions: Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>;
   astNode: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>;
+  isOneOf: boolean;
 
   private _fields: ThunkObjMap<GraphQLField<TSource, TContext>>;
   private _interfaces: ThunkReadonlyArray<GraphQLInterfaceType>;
@@ -768,6 +769,7 @@ export class GraphQLObjectType<TSource = any, TContext = any> {
     this.extensions = toObjMap(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
+    this.isOneOf = config.isOneOf ?? false;
 
     this._fields = () => defineFieldMap(config);
     this._interfaces = () => defineInterfaces(config);
@@ -936,6 +938,7 @@ export interface GraphQLObjectTypeConfig<TSource, TContext> {
   extensions?: Maybe<Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>>;
   astNode?: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
+  isOneOf?: boolean;
 }
 
 interface GraphQLObjectTypeNormalizedConfig<TSource, TContext>
@@ -1605,6 +1608,7 @@ export class GraphQLInputObjectType {
   extensions: Readonly<GraphQLInputObjectTypeExtensions>;
   astNode: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>;
+  isOneOf: boolean;
 
   private _fields: ThunkObjMap<GraphQLInputField>;
 
@@ -1614,6 +1618,7 @@ export class GraphQLInputObjectType {
     this.extensions = toObjMap(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
+    this.isOneOf = config.isOneOf ?? false;
 
     this._fields = defineInputFieldMap.bind(undefined, config);
   }
@@ -1646,6 +1651,7 @@ export class GraphQLInputObjectType {
       extensions: this.extensions,
       astNode: this.astNode,
       extensionASTNodes: this.extensionASTNodes,
+      isOneOf: this.isOneOf,
     };
   }
 
@@ -1691,6 +1697,7 @@ export interface GraphQLInputObjectTypeConfig {
   extensions?: Maybe<Readonly<GraphQLInputObjectTypeExtensions>>;
   astNode?: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<InputObjectTypeExtensionNode>>;
+  isOneOf?: boolean;
 }
 
 interface GraphQLInputObjectTypeNormalizedConfig

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -210,6 +210,17 @@ export const GraphQLSpecifiedByDirective: GraphQLDirective =
   });
 
 /**
+ * Used to declare an Input Object as a Oneof Input Objects and an Object as a Oneof Object.
+ */
+export const GraphQLOneOfDirective: GraphQLDirective = new GraphQLDirective({
+  name: 'oneOf',
+  description:
+    'Indicates an Object is a Oneof Object or an Input Object is a Oneof Input Object.',
+  locations: [DirectiveLocation.OBJECT, DirectiveLocation.INPUT_OBJECT],
+  args: {},
+});
+
+/**
  * The full list of specified directives.
  */
 export const specifiedDirectives: ReadonlyArray<GraphQLDirective> =
@@ -218,6 +229,7 @@ export const specifiedDirectives: ReadonlyArray<GraphQLDirective> =
     GraphQLSkipDirective,
     GraphQLDeprecatedDirective,
     GraphQLSpecifiedByDirective,
+    GraphQLOneOfDirective,
   ]);
 
 export function isSpecifiedDirective(directive: GraphQLDirective): boolean {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -133,6 +133,7 @@ export {
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
+  GraphQLOneOfDirective,
   // Constant Deprecation Reason
   DEFAULT_DEPRECATION_REASON,
 } from './directives';

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -323,6 +323,16 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
         type: __Type,
         resolve: (type) => ('ofType' in type ? type.ofType : undefined),
       },
+      oneOf: {
+        type: GraphQLBoolean,
+        resolve: (type) => {
+          if (isInputObjectType(type) || isObjectType(type)) {
+            return type.isOneOf;
+          }
+
+          return null;
+        },
+      },
     } as GraphQLFieldConfigMap<GraphQLType, unknown>),
 });
 

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -20,6 +20,7 @@ import { isEqualType, isTypeSubTypeOf } from '../utilities/typeComparators';
 
 import type {
   GraphQLEnumType,
+  GraphQLField,
   GraphQLInputField,
   GraphQLInputObjectType,
   GraphQLInterfaceType,
@@ -308,6 +309,23 @@ function validateFields(
         );
       }
     }
+
+    if (isObjectType(type) && type.isOneOf) {
+      validateOneOfObjectField(type, field, context);
+    }
+  }
+}
+
+function validateOneOfObjectField(
+  type: GraphQLObjectType,
+  field: GraphQLField<unknown, unknown, unknown>,
+  context: SchemaValidationContext,
+): void {
+  if (isNonNullType(field.type)) {
+    context.reportError(
+      `Field ${type.name}.${field.name} must be nullable as it is part of a Oneof Type.`,
+      field.astNode?.type,
+    );
   }
 }
 
@@ -531,6 +549,30 @@ function validateInputFields(
         [getDeprecatedDirectiveNode(field.astNode), field.astNode?.type],
       );
     }
+
+    if (inputObj.isOneOf) {
+      validateOneOfInputObjectField(inputObj, field, context);
+    }
+  }
+}
+
+function validateOneOfInputObjectField(
+  type: GraphQLInputObjectType,
+  field: GraphQLInputField,
+  context: SchemaValidationContext,
+): void {
+  if (isNonNullType(field.type)) {
+    context.reportError(
+      `Oneof input field ${type.name}.${field.name} must be nullable.`,
+      field.astNode?.type,
+    );
+  }
+
+  if (field.defaultValue) {
+    context.reportError(
+      `Oneof input field ${type.name}.${field.name} cannot have a default value.`,
+      field.astNode,
+    );
   }
 }
 

--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -23,6 +23,7 @@ import {
   assertDirective,
   GraphQLDeprecatedDirective,
   GraphQLIncludeDirective,
+  GraphQLOneOfDirective,
   GraphQLSkipDirective,
   GraphQLSpecifiedByDirective,
 } from '../../type/directives';
@@ -222,7 +223,7 @@ describe('Schema Builder', () => {
   it('Maintains @include, @skip & @specifiedBy', () => {
     const schema = buildSchema('type Query');
 
-    expect(schema.getDirectives()).to.have.lengthOf(4);
+    expect(schema.getDirectives()).to.have.lengthOf(5);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.equal(GraphQLIncludeDirective);
     expect(schema.getDirective('deprecated')).to.equal(
@@ -231,6 +232,7 @@ describe('Schema Builder', () => {
     expect(schema.getDirective('specifiedBy')).to.equal(
       GraphQLSpecifiedByDirective,
     );
+    expect(schema.getDirective('oneOf')).to.equal(GraphQLOneOfDirective);
   });
 
   it('Overriding directives excludes specified', () => {
@@ -239,9 +241,10 @@ describe('Schema Builder', () => {
       directive @include on FIELD
       directive @deprecated on FIELD_DEFINITION
       directive @specifiedBy on FIELD_DEFINITION
+      directive @oneOf on OBJECT
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(4);
+    expect(schema.getDirectives()).to.have.lengthOf(5);
     expect(schema.getDirective('skip')).to.not.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.not.equal(
       GraphQLIncludeDirective,
@@ -252,18 +255,20 @@ describe('Schema Builder', () => {
     expect(schema.getDirective('specifiedBy')).to.not.equal(
       GraphQLSpecifiedByDirective,
     );
+    expect(schema.getDirective('oneOf')).to.not.equal(GraphQLOneOfDirective);
   });
 
-  it('Adding directives maintains @include, @skip & @specifiedBy', () => {
+  it('Adding directives maintains @include, @skip, @deprecated, @specifiedBy, and @oneOf', () => {
     const schema = buildSchema(`
       directive @foo(arg: Int) on FIELD
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(5);
+    expect(schema.getDirectives()).to.have.lengthOf(6);
     expect(schema.getDirective('skip')).to.not.equal(undefined);
     expect(schema.getDirective('include')).to.not.equal(undefined);
     expect(schema.getDirective('deprecated')).to.not.equal(undefined);
     expect(schema.getDirective('specifiedBy')).to.not.equal(undefined);
+    expect(schema.getDirective('oneOf')).to.not.equal(undefined);
   });
 
   it('Type modifiers', () => {

--- a/src/utilities/__tests__/findBreakingChanges-test.ts
+++ b/src/utilities/__tests__/findBreakingChanges-test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import {
   GraphQLDeprecatedDirective,
   GraphQLIncludeDirective,
+  GraphQLOneOfDirective,
   GraphQLSkipDirective,
   GraphQLSpecifiedByDirective,
 } from '../../type/directives';
@@ -802,6 +803,7 @@ describe('findBreakingChanges', () => {
         GraphQLSkipDirective,
         GraphQLIncludeDirective,
         GraphQLSpecifiedByDirective,
+        GraphQLOneOfDirective,
       ],
     });
 

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -703,6 +703,7 @@ describe('Type System Printer', () => {
         enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
         inputFields(includeDeprecated: Boolean = false): [__InputValue!]
         ofType: __Type
+        oneOf: Boolean
       }
 
       """An enum describing what kind of type a given \`__Type\` is."""

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -657,6 +657,11 @@ describe('Type System Printer', () => {
       ) on SCALAR
 
       """
+      Indicates an Object is a Oneof Object or an Input Object is a Oneof Input Object.
+      """
+      directive @oneOf on OBJECT | INPUT_OBJECT
+
+      """
       A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
       """
       type __Schema {

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -66,6 +66,7 @@ import {
 import {
   GraphQLDeprecatedDirective,
   GraphQLDirective,
+  GraphQLOneOfDirective,
   GraphQLSpecifiedByDirective,
 } from '../type/directives';
 import { introspectionTypes, isIntrospectionType } from '../type/introspection';
@@ -592,6 +593,7 @@ export function extendSchemaImpl(
           fields: () => buildFieldMap(allNodes),
           astNode,
           extensionASTNodes,
+          isOneOf: isOneOf(astNode),
         });
       }
       case Kind.INTERFACE_TYPE_DEFINITION: {
@@ -646,6 +648,7 @@ export function extendSchemaImpl(
           fields: () => buildInputFieldMap(allNodes),
           astNode,
           extensionASTNodes,
+          isOneOf: isOneOf(astNode),
         });
       }
     }
@@ -681,4 +684,13 @@ function getSpecifiedByURL(
   const specifiedBy = getDirectiveValues(GraphQLSpecifiedByDirective, node);
   // @ts-expect-error validated by `getDirectiveValues`
   return specifiedBy?.url;
+}
+
+/**
+ * Given an input object node, returns if the node should be OneOf.
+ */
+function isOneOf(
+  node: InputObjectTypeDefinitionNode | ObjectTypeDefinitionNode,
+): boolean {
+  return Boolean(getDirectiveValues(GraphQLOneOfDirective, node));
 }


### PR DESCRIPTION
This sets the groundwork for an implementation of https://github.com/graphql/graphql-spec/pull/825 for Objects and Input Objects (Oneof Fields omitted for now) by adding `@oneOf` as a built-in directive and exposing `__Type.oneOf` during schema introspection.