### PR TITLE
Enforce Oneof Input Object specification during the validation phase

### DIFF
--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -874,6 +874,28 @@ describe('Validate: Values of correct type', () => {
     });
   });
 
+  describe('Valid oneof input object value', () => {
+    it('Exactly one field', () => {
+      expectValid(`
+        {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: "abc" })
+          }
+        }
+      `);
+    });
+
+    it('Exactly one non-nullable variable', () => {
+      expectValid(`
+        query ($string: String!) {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: $string })
+          }
+        }
+      `);
+    });
+  });
+
   describe('Invalid input object value', () => {
     it('Partial object, missing required', () => {
       expectErrors(`
@@ -1038,6 +1060,70 @@ describe('Validate: Values of correct type', () => {
           }
         `,
       );
+    });
+  });
+
+  describe('Invalid oneof input object value', () => {
+    it('Invalid field type', () => {
+      expectErrors(`
+        {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: 2 })
+          }
+        }
+      `).toDeepEqual([
+        {
+          message: 'String cannot represent a non string value: 2',
+          locations: [{ line: 4, column: 52 }],
+        },
+      ]);
+    });
+
+    it('Exactly one null field', () => {
+      expectErrors(`
+        {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: null })
+          }
+        }
+      `).toDeepEqual([
+        {
+          message: 'Field "OneOfInput.stringField" must be non-null.',
+          locations: [{ line: 4, column: 37 }],
+        },
+      ]);
+    });
+
+    it('Exactly one nullable variable', () => {
+      expectErrors(`
+        query ($string: String) {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: $string })
+          }
+        }
+      `).toDeepEqual([
+        {
+          message:
+            'Variable "string" must be non-nullable to be used for Oneof Input Object "OneOfInput".',
+          locations: [{ line: 4, column: 37 }],
+        },
+      ]);
+    });
+
+    it('More than one field', () => {
+      expectErrors(`
+        {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: "abc", intField: 123 })
+          }
+        }
+      `).toDeepEqual([
+        {
+          message:
+            'Oneof Input Object "OneOfInput" must specify exactly one key.',
+          locations: [{ line: 4, column: 37 }],
+        },
+      ]);
     });
   });
 

--- a/src/validation/__tests__/harness.ts
+++ b/src/validation/__tests__/harness.ts
@@ -79,6 +79,11 @@ export const testSchema: GraphQLSchema = buildSchema(`
     stringListField: [String]
   }
 
+  input OneOfInput @oneOf {
+    stringField: String
+    intField: Int
+  }
+
   type ComplicatedArgs {
     # TODO List
     # TODO Coercion
@@ -93,6 +98,7 @@ export const testSchema: GraphQLSchema = buildSchema(`
     stringListArgField(stringListArg: [String]): String
     stringListNonNullArgField(stringListNonNullArg: [String!]): String
     complexArgField(complexArg: ComplexInput): String
+    oneOfArgField(oneOfArg: OneOfInput): String
     multipleReqs(req1: Int!, req2: Int!): String
     nonNullFieldWithDefault(arg: Int! = 0): String
     multipleOpts(opt1: Int = 0, opt2: Int = 0): String

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -1,14 +1,22 @@
 import { didYouMean } from '../../jsutils/didYouMean';
 import { inspect } from '../../jsutils/inspect';
 import { keyMap } from '../../jsutils/keyMap';
+import type { ObjMap } from '../../jsutils/ObjMap';
 import { suggestionList } from '../../jsutils/suggestionList';
 
 import { GraphQLError } from '../../error/GraphQLError';
 
-import type { ValueNode } from '../../language/ast';
+import type {
+  ObjectFieldNode,
+  ObjectValueNode,
+  ValueNode,
+  VariableDefinitionNode,
+} from '../../language/ast';
+import { Kind } from '../../language/kinds';
 import { print } from '../../language/printer';
 import type { ASTVisitor } from '../../language/visitor';
 
+import type { GraphQLInputObjectType } from '../../type/definition';
 import {
   getNamedType,
   getNullableType,
@@ -32,7 +40,17 @@ import type { ValidationContext } from '../ValidationContext';
 export function ValuesOfCorrectTypeRule(
   context: ValidationContext,
 ): ASTVisitor {
+  let variableDefinitions: { [key: string]: VariableDefinitionNode } = {};
+
   return {
+    OperationDefinition: {
+      enter() {
+        variableDefinitions = {};
+      },
+    },
+    VariableDefinition(definition) {
+      variableDefinitions[definition.variable.name.value] = definition;
+    },
     ListValue(node) {
       // Note: TypeInfo will traverse into a list's item type, so look to the
       // parent input type to check if it is a list.
@@ -61,6 +79,16 @@ export function ValuesOfCorrectTypeRule(
             ),
           );
         }
+      }
+
+      if (type.isOneOf) {
+        validateOneOfInputObject(
+          context,
+          node,
+          type,
+          fieldNodeMap,
+          variableDefinitions,
+        );
       }
     },
     ObjectField(node) {
@@ -150,6 +178,56 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
           undefined,
           undefined,
           error, // Ensure a reference to the original error is maintained.
+        ),
+      );
+    }
+  }
+}
+
+function validateOneOfInputObject(
+  context: ValidationContext,
+  node: ObjectValueNode,
+  type: GraphQLInputObjectType,
+  fieldNodeMap: ObjMap<ObjectFieldNode>,
+  variableDefinitions: { [key: string]: VariableDefinitionNode },
+): void {
+  const keys = Object.keys(fieldNodeMap);
+  const isNotExactlyOneField = keys.length !== 1;
+
+  if (isNotExactlyOneField) {
+    context.reportError(
+      new GraphQLError(
+        `Oneof Input Object "${type.name}" must specify exactly one key.`,
+        node,
+      ),
+    );
+    return;
+  }
+
+  const value = fieldNodeMap[keys[0]].value;
+  const isNullLiteral = value.kind === Kind.NULL;
+  const isVariable = value.kind === Kind.VARIABLE;
+
+  if (isNullLiteral) {
+    context.reportError(
+      new GraphQLError(
+        `Field "${type.name}.${keys[0]}" must be non-null.`,
+        node,
+      ),
+    );
+    return;
+  }
+
+  if (isVariable) {
+    const variableName = value.name.value;
+    const definition = variableDefinitions[variableName];
+    const isNullableVariable = definition.type.kind !== Kind.NON_NULL_TYPE;
+
+    if (isNullableVariable) {
+      context.reportError(
+        new GraphQLError(
+          `Variable "${variableName}" must be non-nullable to be used for Oneof Input Object "${type.name}".`,
+          node,
         ),
       );
     }


### PR DESCRIPTION
This adds checks to the validation phase to ensure Oneof Input Objects are valid based on what is known from the operation document (i.e., before executing the query).

This checks:
- Oneof Input Objects have exactly one field provided with the correct non-null, type for that field.
- A variable used in a Oneof Input Object must be non-nullable.

[RFC section for reference](https://github.com/graphql/graphql-spec/pull/825/files#diff-607ee7e6b71821eecadde7d92451b978e8a75e23d596150950799dc5f8afa43eR1469).