### PR TITLE
Enforce Oneof behavior at execution time

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -20,7 +20,6 @@ words:
   - graphiql
   - sublinks
   - instanceof
-  - oneof
 
   # Different names used inside tests
   - Skywalker

--- a/src/execution/__tests__/oneof-test.ts
+++ b/src/execution/__tests__/oneof-test.ts
@@ -37,6 +37,20 @@ function executeQuery(
   return execute({ schema, document: parse(query), rootValue, variableValues });
 }
 
+async function executeQueryAsync(
+  query: string,
+  rootValue: unknown,
+  variableValues?: { [variable: string]: unknown },
+): Promise<ExecutionResult> {
+  const result = await execute({
+    schema,
+    document: parse(query),
+    rootValue,
+    variableValues,
+  });
+  return result;
+}
+
 describe('Execute: Handles Oneof Input Objects and Oneof Objects', () => {
   describe('Oneof Input Objects', () => {
     const rootValue = {
@@ -132,6 +146,125 @@ describe('Execute: Handles Oneof Input Objects and Oneof Objects', () => {
             locations: [{ column: 16, line: 2 }],
             message:
               'Variable "$input" got invalid value { a: "abc", b: 123 }; Exactly one key must be specified.',
+          },
+        ],
+      });
+    });
+  });
+
+  describe('Oneof Objects', () => {
+    const query = `
+        query ($input: TestInputObject! = {a: "abc"}) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+
+    it('works with a single, non-null value', () => {
+      const rootValue = {
+        test: {
+          a: null,
+          b: 123,
+        },
+      };
+      const result = executeQuery(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: {
+            a: null,
+            b: 123,
+          },
+        },
+      });
+    });
+
+    it('works with a single, non-null, async value', async () => {
+      const rootValue = {
+        test() {
+          return {
+            a: null,
+            b: () => new Promise((resolve) => resolve(123)),
+          };
+        },
+      };
+      const result = await executeQueryAsync(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: {
+            a: null,
+            b: 123,
+          },
+        },
+      });
+    });
+
+    it('errors when there are no non-null values', () => {
+      const rootValue = {
+        test: {
+          a: null,
+          b: null,
+        },
+      };
+      const result = executeQuery(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: { test: null },
+        errors: [
+          {
+            locations: [{ column: 11, line: 3 }],
+            message:
+              'Oneof Object "TestObject" must have exactly one non-null field but got 0.',
+            path: ['test'],
+          },
+        ],
+      });
+    });
+
+    it('errors when there are multiple non-null values', () => {
+      const rootValue = {
+        test: {
+          a: 'abc',
+          b: 456,
+        },
+      };
+      const result = executeQuery(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: { test: null },
+        errors: [
+          {
+            locations: [{ column: 11, line: 3 }],
+            message:
+              'Oneof Object "TestObject" must have exactly one non-null field but got 2.',
+            path: ['test'],
+          },
+        ],
+      });
+    });
+
+    it('errors when there are multiple non-null, async values', async () => {
+      const rootValue = {
+        test() {
+          return {
+            a: 'abc',
+            b: () => new Promise((resolve) => resolve(123)),
+          };
+        },
+      };
+      const result = await executeQueryAsync(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: { test: null },
+        errors: [
+          {
+            locations: [{ column: 11, line: 3 }],
+            message:
+              'Oneof Object "TestObject" must have exactly one non-null field but got 2.',
+            path: ['test'],
           },
         ],
       });

--- a/src/execution/__tests__/oneof-test.ts
+++ b/src/execution/__tests__/oneof-test.ts
@@ -1,0 +1,140 @@
+import { describe, it } from 'mocha';
+
+import { expectJSON } from '../../__testUtils__/expectJSON';
+
+import { parse } from '../../language/parser';
+
+import { buildSchema } from '../../utilities/buildASTSchema';
+
+import type { ExecutionResult } from '../execute';
+import { execute } from '../execute';
+
+const schema = buildSchema(`
+  type Query {
+    test(input: TestInputObject!): TestObject
+  }
+
+  input TestInputObject @oneOf {
+    a: String
+    b: Int
+  }
+
+  type TestObject @oneOf {
+    a: String
+    b: Int
+  }
+
+  schema {
+    query: Query
+  }
+`);
+
+function executeQuery(
+  query: string,
+  rootValue: unknown,
+  variableValues?: { [variable: string]: unknown },
+): ExecutionResult | Promise<ExecutionResult> {
+  return execute({ schema, document: parse(query), rootValue, variableValues });
+}
+
+describe('Execute: Handles Oneof Input Objects and Oneof Objects', () => {
+  describe('Oneof Input Objects', () => {
+    const rootValue = {
+      test({ input }: { input: { a?: string; b?: number } }) {
+        return input;
+      },
+    };
+
+    it('accepts a good default value', () => {
+      const query = `
+        query ($input: TestInputObject! = {a: "abc"}) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: {
+            a: 'abc',
+            b: null,
+          },
+        },
+      });
+    });
+
+    it('rejects a bad default value', () => {
+      const query = `
+        query ($input: TestInputObject! = {a: "abc", b: 123}) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: null,
+        },
+        errors: [
+          {
+            locations: [{ column: 23, line: 3 }],
+            message:
+              'Argument "input" of non-null type "TestInputObject!" must not be null.',
+            path: ['test'],
+          },
+        ],
+      });
+    });
+
+    it('accepts a good variable', () => {
+      const query = `
+        query ($input: TestInputObject!) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue, { input: { a: 'abc' } });
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: {
+            a: 'abc',
+            b: null,
+          },
+        },
+      });
+    });
+
+    it('rejects a bad variable', () => {
+      const query = `
+        query ($input: TestInputObject!) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue, {
+        input: { a: 'abc', b: 123 },
+      });
+
+      expectJSON(result).toDeepEqual({
+        errors: [
+          {
+            locations: [{ column: 16, line: 2 }],
+            message:
+              'Variable "$input" got invalid value { a: "abc", b: 123 }; Exactly one key must be specified.',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/execution/__tests__/oneof-test.ts
+++ b/src/execution/__tests__/oneof-test.ts
@@ -51,8 +51,8 @@ async function executeQueryAsync(
   return result;
 }
 
-describe('Execute: Handles Oneof Input Objects and Oneof Objects', () => {
-  describe('Oneof Input Objects', () => {
+describe('Execute: Handles OneOf Input Objects and OneOf Objects', () => {
+  describe('OneOf Input Objects', () => {
     const rootValue = {
       test({ input }: { input: { a?: string; b?: number } }) {
         return input;
@@ -152,7 +152,7 @@ describe('Execute: Handles Oneof Input Objects and Oneof Objects', () => {
     });
   });
 
-  describe('Oneof Objects', () => {
+  describe('OneOf Objects', () => {
     const query = `
         query ($input: TestInputObject! = {a: "abc"}) {
           test(input: $input) {
@@ -217,7 +217,7 @@ describe('Execute: Handles Oneof Input Objects and Oneof Objects', () => {
           {
             locations: [{ column: 11, line: 3 }],
             message:
-              'Oneof Object "TestObject" must have exactly one non-null field but got 0.',
+              'OneOf Object "TestObject" must have exactly one non-null field but got 0.',
             path: ['test'],
           },
         ],
@@ -239,7 +239,7 @@ describe('Execute: Handles Oneof Input Objects and Oneof Objects', () => {
           {
             locations: [{ column: 11, line: 3 }],
             message:
-              'Oneof Object "TestObject" must have exactly one non-null field but got 2.',
+              'OneOf Object "TestObject" must have exactly one non-null field but got 2.',
             path: ['test'],
           },
         ],
@@ -263,7 +263,7 @@ describe('Execute: Handles Oneof Input Objects and Oneof Objects', () => {
           {
             locations: [{ column: 11, line: 3 }],
             message:
-              'Oneof Object "TestObject" must have exactly one non-null field but got 2.',
+              'OneOf Object "TestObject" must have exactly one non-null field but got 2.',
             path: ['test'],
           },
         ],

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -998,7 +998,7 @@ function validateOneOfValue(
 
   if (nonNullCount !== 1) {
     throw new GraphQLError(
-      `Oneof Object "${returnType.name}" must have exactly one non-null field but got ${nonNullCount}.`,
+      `OneOf Object "${returnType.name}" must have exactly one non-null field but got ${nonNullCount}.`,
       fieldNodes,
     );
   }

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -927,12 +927,13 @@ function completeObjectValue(
         if (!resolvedIsTypeOf) {
           throw invalidReturnTypeError(returnType, result, fieldNodes);
         }
-        return executeFields(
+        return executeFieldsWithOneOfValidation(
           exeContext,
           returnType,
           result,
           path,
           subFieldNodes,
+          fieldNodes,
         );
       });
     }
@@ -942,7 +943,65 @@ function completeObjectValue(
     }
   }
 
-  return executeFields(exeContext, returnType, result, path, subFieldNodes);
+  return executeFieldsWithOneOfValidation(
+    exeContext,
+    returnType,
+    result,
+    path,
+    subFieldNodes,
+    fieldNodes,
+  );
+}
+
+function executeFieldsWithOneOfValidation(
+  exeContext: ExecutionContext,
+  parentType: GraphQLObjectType,
+  sourceValue: unknown,
+  path: Path | undefined,
+  fields: Map<string, ReadonlyArray<FieldNode>>,
+  fieldNodes: ReadonlyArray<FieldNode>,
+): PromiseOrValue<ObjMap<unknown>> {
+  const value = executeFields(
+    exeContext,
+    parentType,
+    sourceValue,
+    path,
+    fields,
+  );
+  if (!parentType.isOneOf) {
+    return value;
+  }
+
+  if (isPromise(value)) {
+    return value.then((resolvedValue) => {
+      validateOneOfValue(resolvedValue, parentType, fieldNodes);
+      return resolvedValue;
+    });
+  }
+
+  validateOneOfValue(value, parentType, fieldNodes);
+  return value;
+}
+
+function validateOneOfValue(
+  value: ObjMap<unknown>,
+  returnType: GraphQLObjectType,
+  fieldNodes: ReadonlyArray<FieldNode>,
+): void {
+  let nonNullCount = 0;
+
+  for (const field in value) {
+    if (value[field] !== null) {
+      nonNullCount += 1;
+    }
+  }
+
+  if (nonNullCount !== 1) {
+    throw new GraphQLError(
+      `Oneof Object "${returnType.name}" must have exactly one non-null field but got ${nonNullCount}.`,
+      fieldNodes,
+    );
+  }
 }
 
 function invalidReturnTypeError(

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -1663,7 +1663,7 @@ describe('Type System: Input Object fields must have input types', () => {
   });
 });
 
-describe('Type System: Oneof Object fields must be nullable', () => {
+describe('Type System: OneOf Object fields must be nullable', () => {
   it('rejects non-nullable fields', () => {
     const schema = buildSchema(`
       type Query {
@@ -1678,14 +1678,14 @@ describe('Type System: Oneof Object fields must be nullable', () => {
     expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
-          'Field SomeObject.b must be nullable as it is part of a Oneof Type.',
+          'Field SomeObject.b must be nullable as it is part of a OneOf Type.',
         locations: [{ line: 8, column: 12 }],
       },
     ]);
   });
 });
 
-describe('Type System: Oneof Input Object fields must be nullable', () => {
+describe('Type System: OneOf Input Object fields must be nullable', () => {
   it('rejects non-nullable fields', () => {
     const schema = buildSchema(`
       type Query {
@@ -1699,7 +1699,7 @@ describe('Type System: Oneof Input Object fields must be nullable', () => {
     `);
     expectJSON(validateSchema(schema)).toDeepEqual([
       {
-        message: 'Oneof input field SomeInputObject.b must be nullable.',
+        message: 'OneOf input field SomeInputObject.b must be nullable.',
         locations: [{ line: 8, column: 12 }],
       },
     ]);
@@ -1719,7 +1719,7 @@ describe('Type System: Oneof Input Object fields must be nullable', () => {
     expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
-          'Oneof input field SomeInputObject.b cannot have a default value.',
+          'OneOf input field SomeInputObject.b cannot have a default value.',
         locations: [{ line: 8, column: 9 }],
       },
     ]);

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -210,12 +210,12 @@ export const GraphQLSpecifiedByDirective: GraphQLDirective =
   });
 
 /**
- * Used to declare an Input Object as a Oneof Input Objects and an Object as a Oneof Object.
+ * Used to declare an Input Object as a OneOf Input Objects and an Object as a OneOf Object.
  */
 export const GraphQLOneOfDirective: GraphQLDirective = new GraphQLDirective({
   name: 'oneOf',
   description:
-    'Indicates an Object is a Oneof Object or an Input Object is a Oneof Input Object.',
+    'Indicates an Object is a OneOf Object or an Input Object is a OneOf Input Object.',
   locations: [DirectiveLocation.OBJECT, DirectiveLocation.INPUT_OBJECT],
   args: {},
 });

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -323,7 +323,7 @@ function validateOneOfObjectField(
 ): void {
   if (isNonNullType(field.type)) {
     context.reportError(
-      `Field ${type.name}.${field.name} must be nullable as it is part of a Oneof Type.`,
+      `Field ${type.name}.${field.name} must be nullable as it is part of a OneOf Type.`,
       field.astNode?.type,
     );
   }
@@ -563,14 +563,14 @@ function validateOneOfInputObjectField(
 ): void {
   if (isNonNullType(field.type)) {
     context.reportError(
-      `Oneof input field ${type.name}.${field.name} must be nullable.`,
+      `OneOf input field ${type.name}.${field.name} must be nullable.`,
       field.astNode?.type,
     );
   }
 
   if (field.defaultValue) {
     context.reportError(
-      `Oneof input field ${type.name}.${field.name} cannot have a default value.`,
+      `OneOf input field ${type.name}.${field.name} cannot have a default value.`,
       field.astNode,
     );
   }

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -273,6 +273,108 @@ describe('coerceInputValue', () => {
     });
   });
 
+  describe('for GraphQLInputObject that isOneOf', () => {
+    const TestInputObject = new GraphQLInputObjectType({
+      name: 'TestInputObject',
+      fields: {
+        foo: { type: GraphQLInt },
+        bar: { type: GraphQLInt },
+      },
+      isOneOf: true,
+    });
+
+    it('returns no error for a valid input', () => {
+      const result = coerceValue({ foo: 123 }, TestInputObject);
+      expectValue(result).to.deep.equal({ foo: 123 });
+    });
+
+    it('returns an error if more than one field is specified', () => {
+      const result = coerceValue({ foo: 123, bar: null }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Exactly one key must be specified.',
+          path: [],
+          value: { foo: 123, bar: null },
+        },
+      ]);
+    });
+
+    it('returns an error the one field is null', () => {
+      const result = coerceValue({ bar: null }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Field "bar" must be non-null.',
+          path: ['bar'],
+          value: null,
+        },
+      ]);
+    });
+
+    it('returns an error for an invalid field', () => {
+      const result = coerceValue({ foo: NaN }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Int cannot represent non-integer value: NaN',
+          path: ['foo'],
+          value: NaN,
+        },
+      ]);
+    });
+
+    it('returns multiple errors for multiple invalid fields', () => {
+      const result = coerceValue({ foo: 'abc', bar: 'def' }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Int cannot represent non-integer value: "abc"',
+          path: ['foo'],
+          value: 'abc',
+        },
+        {
+          error: 'Int cannot represent non-integer value: "def"',
+          path: ['bar'],
+          value: 'def',
+        },
+        {
+          error: 'Exactly one key must be specified.',
+          path: [],
+          value: { foo: 'abc', bar: 'def' },
+        },
+      ]);
+    });
+
+    it('returns error for an unknown field', () => {
+      const result = coerceValue(
+        { foo: 123, unknownField: 123 },
+        TestInputObject,
+      );
+      expectErrors(result).to.deep.equal([
+        {
+          error:
+            'Field "unknownField" is not defined by type "TestInputObject".',
+          path: [],
+          value: { foo: 123, unknownField: 123 },
+        },
+      ]);
+    });
+
+    it('returns error for a misspelled field', () => {
+      const result = coerceValue({ bart: 123 }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error:
+            'Field "bart" is not defined by type "TestInputObject". Did you mean "bar"?',
+          path: [],
+          value: { bart: 123 },
+        },
+        {
+          error: 'Exactly one key must be specified.',
+          path: [],
+          value: { bart: 123 },
+        },
+      ]);
+    });
+  });
+
   describe('for GraphQLInputObject with default value', () => {
     const makeTestInputObject = (defaultValue: any) =>
       new GraphQLInputObjectType({

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -657,7 +657,7 @@ describe('Type System Printer', () => {
       ) on SCALAR
 
       """
-      Indicates an Object is a Oneof Object or an Input Object is a Oneof Input Object.
+      Indicates an Object is a OneOf Object or an Input Object is a OneOf Input Object.
       """
       directive @oneOf on OBJECT | INPUT_OBJECT
 

--- a/src/utilities/__tests__/valueFromAST-test.ts
+++ b/src/utilities/__tests__/valueFromAST-test.ts
@@ -196,6 +196,14 @@ describe('valueFromAST', () => {
       requiredBool: { type: nonNullBool },
     },
   });
+  const testOneOfInputObj = new GraphQLInputObjectType({
+    name: 'TestOneOfInput',
+    fields: {
+      a: { type: GraphQLString },
+      b: { type: GraphQLString },
+    },
+    isOneOf: true,
+  });
 
   it('coerces input objects according to input coercion rules', () => {
     expectValueFrom('null', testInputObj).to.equal(null);
@@ -221,6 +229,16 @@ describe('valueFromAST', () => {
     );
     expectValueFrom('{ requiredBool: null }', testInputObj).to.equal(undefined);
     expectValueFrom('{ bool: true }', testInputObj).to.equal(undefined);
+    expectValueFrom('{ a: "abc" }', testOneOfInputObj).to.deep.equal({
+      a: 'abc',
+    });
+    expectValueFrom('{ a: null }', testOneOfInputObj).to.equal(undefined);
+    expectValueFrom('{ a: 1 }', testOneOfInputObj).to.equal(undefined);
+    expectValueFrom('{ a: "abc", b: "def" }', testOneOfInputObj).to.equal(
+      undefined,
+    );
+    expectValueFrom('{}', testOneOfInputObj).to.equal(undefined);
+    expectValueFrom('{ c: "abc" }', testOneOfInputObj).to.equal(undefined);
   });
 
   it('accepts variable values assuming already coerced', () => {

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -142,6 +142,28 @@ function coerceInputValueImpl(
         );
       }
     }
+
+    if (type.isOneOf) {
+      const keys = Object.keys(coercedValue);
+      if (keys.length !== 1) {
+        onError(
+          pathToArray(path),
+          inputValue,
+          new GraphQLError('Exactly one key must be specified.'),
+        );
+      }
+
+      const key = keys[0];
+      const value = coercedValue[key];
+      if (value === null) {
+        onError(
+          pathToArray(path).concat(key),
+          value,
+          new GraphQLError(`Field "${key}" must be non-null.`),
+        );
+      }
+    }
+
     return coercedValue;
   }
 

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -125,6 +125,18 @@ export function valueFromAST(
       }
       coercedObj[field.name] = fieldValue;
     }
+
+    if (type.isOneOf) {
+      const keys = Object.keys(coercedObj);
+      if (keys.length !== 1) {
+        return; // Invalid: not exactly one key, intentionally return no value.
+      }
+
+      if (coercedObj[keys[0]] === null) {
+        return; // Invalid: value not non-null, intentionally return no value.
+      }
+    }
+
     return coercedObj;
   }
 

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -874,7 +874,7 @@ describe('Validate: Values of correct type', () => {
     });
   });
 
-  describe('Valid oneof input object value', () => {
+  describe('Valid oneOf input object value', () => {
     it('Exactly one field', () => {
       expectValid(`
         {
@@ -1063,7 +1063,7 @@ describe('Validate: Values of correct type', () => {
     });
   });
 
-  describe('Invalid oneof input object value', () => {
+  describe('Invalid oneOf input object value', () => {
     it('Invalid field type', () => {
       expectErrors(`
         {
@@ -1104,7 +1104,7 @@ describe('Validate: Values of correct type', () => {
       `).toDeepEqual([
         {
           message:
-            'Variable "string" must be non-nullable to be used for Oneof Input Object "OneOfInput".',
+            'Variable "string" must be non-nullable to be used for OneOf Input Object "OneOfInput".',
           locations: [{ line: 4, column: 37 }],
         },
       ]);
@@ -1120,7 +1120,7 @@ describe('Validate: Values of correct type', () => {
       `).toDeepEqual([
         {
           message:
-            'Oneof Input Object "OneOfInput" must specify exactly one key.',
+            'OneOf Input Object "OneOfInput" must specify exactly one key.',
           locations: [{ line: 4, column: 37 }],
         },
       ]);

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -197,7 +197,7 @@ function validateOneOfInputObject(
   if (isNotExactlyOneField) {
     context.reportError(
       new GraphQLError(
-        `Oneof Input Object "${type.name}" must specify exactly one key.`,
+        `OneOf Input Object "${type.name}" must specify exactly one key.`,
         node,
       ),
     );
@@ -226,7 +226,7 @@ function validateOneOfInputObject(
     if (isNullableVariable) {
       context.reportError(
         new GraphQLError(
-          `Variable "${variableName}" must be non-nullable to be used for Oneof Input Object "${type.name}".`,
+          `Variable "${variableName}" must be non-nullable to be used for OneOf Input Object "${type.name}".`,
           node,
         ),
       );


### PR DESCRIPTION
This enforces the behavior of Oneof Input Object and Oneof Objects during the execution phase of fulfilling a GraphQL request.